### PR TITLE
remove import from process

### DIFF
--- a/apps/auth-api/src/tracing.ts
+++ b/apps/auth-api/src/tracing.ts
@@ -18,7 +18,6 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import { NodeSDK } from '@opentelemetry/sdk-node';
-import * as process from 'process';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { ExpressInstrumentation } from '@opentelemetry/instrumentation-express';
 


### PR DESCRIPTION
In Node.js, `process` is a global object and does not need to be imported. When you do `import * as process from 'process';`, you are essentially overwriting the global `process` object with a module-scoped variable, which may not have all the properties and methods available on the global `process` object.

When you remove the import `import * as process from 'process';`, the code works because it uses the global `process` object, which does have the `on` method available for hooking into various process-level events.

In most Node.js programs, there's no need to import the `process` object because it's globally available to the application. Removing the import statement will solve the issue you're experiencing.